### PR TITLE
Convert specs to RSpec 3.3.2 syntax with Transpec

### DIFF
--- a/spec/cstruct_spec.rb
+++ b/spec/cstruct_spec.rb
@@ -8,79 +8,105 @@ describe 'Normal Member -> Point' do
 
     class Point < CStruct
       int32:x
-      int32:y 
+      int32:y
     end
 
     point = Point.new
     point.x,point.y = -10,20
-    point      
-  end      
-  its(:x) { should == -10 }
-  its(:y) { should == 20 }
+    point
+  end
+
+  describe '#x' do
+    subject { super().x }
+    it { is_expected.to eq(-10) }
+  end
+
+  describe '#y' do
+    subject { super().y }
+    it { is_expected.to eq(20) }
+  end
 end
 
 describe 'Struct Member -> Line' do
   subject do
     class Point < CStruct
       int32:x
-      int32:y 
+      int32:y
     end
 
     class Line < CStruct
       Point:begin_point
-      Point:end_point 
+      Point:end_point
     end
 
     line = Line.new
-    line.begin_point.x = 10 
+    line.begin_point.x = 10
     line.begin_point.y = 20
-    line      
-  end      
-  its(:'begin_point.x') { should == 10 }
-  its(:'begin_point.y') { should == 20 }
+    line
+  end
+
+  describe '#begin_point' do
+    subject { super().begin_point }
+    describe '#x' do
+      subject { super().x }
+      it { is_expected.to eq(10) }
+    end
+  end
+
+  describe '#begin_point' do
+    subject { super().begin_point }
+    describe '#y' do
+      subject { super().y }
+      it { is_expected.to eq(20) }
+    end
+  end
 end
 
 describe 'Array Member -> Collection' do
   subject do
-    
+
     class Collection < CStruct
       int32:elements,[8]
     end
 
-    collection = Collection.new    
-    
+    collection = Collection.new
+
     (0..7).each do |i|
       collection.elements[i] = i  # assign like as C language
     end
 
-    collection     
-  end 
-  its(:elements) { should == (0..7).to_a }
+    collection
+  end
+
+  describe '#elements' do
+    subject { super().elements }
+    it { is_expected.to eq((0..7).to_a) }
+  end
 end
 
 describe 'Array Struct Member -> PointArray' do
-  it 'PointArray' do  
+  it 'PointArray' do
     class Point < CStruct
       double:x
-      double:y 
+      double:y
     end
 
     class PointArray < CStruct
       Point:elements,[4]
     end
 
-    array = PointArray.new 
-    (0..3).each do |i| 
+    array = PointArray.new
+    (0..3).each do |i|
       array.elements[i].x = i+0.234
       array.elements[i].y = i+1.667
     end
 
-    (0..3).each do |i| 
-      array.elements[i].x.should == i+0.234
-      array.elements[i].y.should == i+1.667
+    (0..3).each do |i|
+      expect(array.elements[i].x).to eq(i+0.234)
+      expect(array.elements[i].y).to eq(i+1.667)
     end
-  end   
-  
+  end
+
 end
 
 
@@ -94,22 +120,36 @@ describe 'Inner Struct Member-> T' do
       Inner :inner
     end
 
-    t = T.new    
+    t = T.new
     t.inner.v1 = 10
     t.inner.v2 = 20
-    t 
-  end 
-  its(:'inner.v1') { should == 10 }
-  its(:'inner.v2') { should == 20 }
+    t
+  end
+
+  describe '#inner' do
+    subject { super().inner }
+    describe '#v1' do
+      subject { super().v1 }
+      it { is_expected.to eq(10) }
+    end
+  end
+
+  describe '#inner' do
+    subject { super().inner }
+    describe '#v2' do
+      subject { super().v2 }
+      it { is_expected.to eq(20) }
+    end
+  end
 end
 
-describe 'Anonymous Struct Member -> Window' do  
+describe 'Anonymous Struct Member -> Window' do
   subject do
     class Window < CStruct
       int32:style
       struct :position do
         int32:x
-        int32:y 
+        int32:y
       end
     end
     window = Window.new
@@ -118,13 +158,30 @@ describe 'Anonymous Struct Member -> Window' do
     window.position.y = 20
     window
   end
-  
-  its(:style)       { should == 1}  
-  its(:'position.x'){ should == 10} 
-  its(:'position.y'){ should == 20} 
+
+  describe '#style' do
+    subject { super().style }
+    it { is_expected.to eq(1)}
+  end
+
+  describe '#position' do
+    subject { super().position }
+    describe '#x' do
+      subject { super().x }
+      it { is_expected.to eq(10)}
+    end
+  end
+
+  describe '#position' do
+    subject { super().position }
+    describe '#y' do
+      subject { super().y }
+      it { is_expected.to eq(20)}
+    end
+  end
 end
 
-describe 'Anonymous Union Member -> U' do  
+describe 'Anonymous Union Member -> U' do
   subject do
     class U < CStruct
         union:value do
@@ -136,8 +193,15 @@ describe 'Anonymous Union Member -> U' do
     u = U.new
     u.value.x = 10
     u
-  end  
-  its(:'value.x'){ should == 10}
+  end
+
+  describe '#value' do
+    subject { super().value }
+    describe '#x' do
+      subject { super().x }
+      it { is_expected.to eq(10)}
+    end
+  end
 end
 
 describe 'Char Buffer Member -> Addition' do
@@ -150,28 +214,34 @@ describe 'Char Buffer Member -> Addition' do
     addition.description = 'Hello Ruby!'
     addition
   end
-  
-  its(:'description.to_cstr') {should == 'Hello Ruby!'}
+
+  describe '#description' do
+    subject { super().description }
+    describe '#to_cstr' do
+      subject { super().to_cstr }
+      it {is_expected.to eq('Hello Ruby!')}
+    end
+  end
 end
 
 =begin
 describe 'Binary File IO ' do
   subject do
- 
+
     class Point < CStruct
       int32:x
-      int32:y 
+      int32:y
     end
 
     class PointF < CStruct
       double:x
-      double:y 
+      double:y
     end
 
     class Addition < CStruct
       char :description,[32]
     end
-    
+
     class IOData < CStruct
       Point:point
       PointF:pointf
@@ -183,8 +253,8 @@ describe 'Binary File IO ' do
     File.open("point.bin","wb")do |f|
         write_data.point   = Point.new {|st| st.x = 100; st.y =200 }
         write_data.point_f = PointF.new{|st| st.x = 20.65; st.y =70.86 }
-      
-        write_data.addition = Addition.new 
+
+        write_data.addition = Addition.new
         write_data.addition.description= "Hello Ruby!"
 
         f.write write_data.data
@@ -193,9 +263,9 @@ describe 'Binary File IO ' do
     read_data = IOData.new
 
     #read file
-    File.open("point.bin","rb")do |f|      
-      read_data   << f.read(IODtata.size)    
-        
+    File.open("point.bin","rb")do |f|
+      read_data   << f.read(IODtata.size)
+
       puts point.x
       puts point.y
       puts point_f.x
@@ -204,7 +274,7 @@ describe 'Binary File IO ' do
     end
     read_data
   end
-  
+
   its(:'point.x') {should == 200}
 end
 =end
@@ -214,27 +284,27 @@ describe 'Namespace ' do
         class A < CStruct
             uint32:handle
         end
-      
+
         module NS2
             class B < CStruct
                 A:a # directly use A
-            end 
+            end
         end
 
         class C < CStruct
           A     :a
           NS2_B :b  # Meaning of the 'NS2_B' is NS2::B
-        end 
+        end
     end
 
     class D < CStruct
         NS1_NS2_B:b # Meaning of the 'NS1_NS2_B' is NS1::NS2::B
-    end 
+    end
 
     v = D.new
     v.b.a.handle = 120
-    v.b.a.handle.should == 120
-    
+    expect(v.b.a.handle).to eq(120)
+
   end
 end
 


### PR DESCRIPTION
- 15 conversions
  from: == expected
    to: eq(expected)
- 12 conversions
  from: it { should ... }
    to: it { is_expected.to ... }
- 12 conversions
  from: its(:attr) { }
    to: describe '#attr' do subject { super().attr }; it { } end
- 3 conversions
  from: obj.should
    to: expect(obj).to
