### PR TITLE
Fix #<< now returns self

### DIFF
--- a/lib/cstruct.rb
+++ b/lib/cstruct.rb
@@ -1,1 +1,1 @@
-require 'cstruct/cstruct'
+require_relative 'cstruct/cstruct'

--- a/lib/cstruct/cstruct.rb
+++ b/lib/cstruct/cstruct.rb
@@ -231,6 +231,7 @@ public
     (0...count).each do |i|
       Utils.string_setbyte @data,i,Utils.string_getbyte(bindata,i)
     end
+    self
   end
     
   def sync_to_owner #:nodoc:


### PR DESCRIPTION
`CStruct.new << 'bindata'` returns a CStruct and not a Range.

Formerly an intermediate var or something this `CStruct.new.tap{ |s| s << 'binstring'` }` was needed